### PR TITLE
Keep the returned order of applications when selecting

### DIFF
--- a/dired-open-with.el
+++ b/dired-open-with.el
@@ -82,9 +82,14 @@ selected application."
                  (concat
                   (make-string (- (+ max-length 2) (length name)) ?\s)
                   annotation)))))
-         (value (completing-read
-                 "Open with: "
-                 (mapcar (lambda (item) (gethash "Name" (cdr item))) items))))
+         (coll (mapcar (lambda (item) (gethash "Name" (cdr item))) items))
+         (value
+          (completing-read
+           "Open with: "
+           (lambda (string pred action)
+             (if (eq action 'metadata)
+                 `(metadata (display-sort-function . identity))
+               (complete-with-action action coll string pred))))))
     (cdr (assoc value items))))
 
 (defun dired-open-with--applications-for-file (path)


### PR DESCRIPTION
Currently some popular completion UIs such as [vertico](https://github.com/minad/vertico), the candidate list is sorted by length by default, therefore the initially selected one isn't the default "open with" application.

On my system when opening ang ".svg" file:
Before this PR:
```
Krita                                                     
Photos                                                   An Image gallery application
Gwenview                                               A simple image viewer
Inkscape                                               Create and edit Scalable Vector Graphics images
KolourPaint                                         An easy-to-use paint program
gImageReader                                       
GNU Image Manipulation Program   Create images and edit photographs
```
After this PR:
```
Gwenview                                               A simple image viewer
Inkscape                                               Create and edit Scalable Vector Graphics images
GNU Image Manipulation Program   Create images and edit photographs
gImageReader                                       
Krita                                                     
Photos                                                   An Image gallery application
KolourPaint                                         An easy-to-use paint program
```

The default is "Gwenview" viewer but previously `dired-open-with` would default to "Krita" editor, the shortest name instead.