### PR TITLE
Add a GitHub action to run tests and linter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,81 @@
+# * test.yml --- Test Emacs packages using makem.sh on GitHub Actions
+
+# URL: https://github.com/alphapapa/makem.sh
+# Version: 0.4.2
+
+# * Commentary:
+
+# Based on Steve Purcell's examples at
+# <https://github.com/purcell/setup-emacs/blob/master/.github/workflows/test.yml>,
+# <https://github.com/purcell/package-lint/blob/master/.github/workflows/test.yml>.
+
+# * License:
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# * Code:
+
+name: "CI"
+on:
+  pull_request:
+  push:
+    # Comment out this section to enable testing of all branches.
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs_version:
+          - 28.1
+          - 29.1
+          - snapshot
+    steps:
+    - uses: purcell/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs_version }}
+
+    - uses: actions/checkout@v2
+
+    - name: Install Ispell
+      run: |
+        sudo apt-get install ispell
+
+    - name: Initialize sandbox
+      run: |
+        wget https://raw.githubusercontent.com/alphapapa/makem.sh/refs/heads/master/makem.sh
+        chmod +x ./makem.sh
+        SANDBOX_DIR=$(mktemp -d) || exit 1
+        echo "SANDBOX_DIR=$SANDBOX_DIR" >> $GITHUB_ENV
+        ./makem.sh -vv --sandbox=$SANDBOX_DIR --install-deps --install-linters
+
+    # The "all" rule is not used, because it treats compilation warnings
+    # as failures, so linting and testing are run as separate steps.
+
+    - name: Lint
+      # NOTE: Uncomment this line to treat lint failures as passing
+      #       so the job doesn't show failure.
+      # continue-on-error: true
+      run: ./makem.sh -vv --sandbox=$SANDBOX_DIR lint
+
+    - name: Test
+      if: always()  # Run test even if linting fails.
+      run: ./makem.sh -vv --sandbox=$SANDBOX_DIR test
+
+# Local Variables:
+# eval: (outline-minor-mode)
+# End:

--- a/dired-open-with.el
+++ b/dired-open-with.el
@@ -29,8 +29,8 @@
 ;;
 ;; This package is built upon freedesktop.org features and therefore works
 ;; only on operating systems and desktop environments that comply with the
-;; XDG specifications. That should be true for the majority of GNU/Linux
-;; distributions and BSD variants. I don't know what is the situation on
+;; XDG specifications.  That should be true for the majority of GNU/Linux
+;; distributions and BSD variants.  I don't know what is the situation on
 ;; MS Windows, macOS, or and mobile systems.
 ;;
 ;; https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
@@ -48,7 +48,7 @@
 
 ;;;###autoload
 (defun dired-open-with ()
-  "An 'Open with' dialog for opening files in external applications from Dired.
+  "An \\='Open with\\=' dialog for opening files in external applications.
 Such dialogs are known from GUI file managers, when right-clicking a file."
   (interactive)
 
@@ -137,6 +137,8 @@ string."
                  (split-string-shell-command cmd))))
 
 ;;;; Footer
+
+;; LocalWords: freedesktop org html ar
 
 (provide 'dired-open-with)
 

--- a/tests/dired-open-with-tests.el
+++ b/tests/dired-open-with-tests.el
@@ -1,0 +1,3 @@
+;;; dired-open-with-tests.el --- Tests for dired-open-with -*- lexical-binding: t; -*-
+
+(require 'ert)


### PR DESCRIPTION
Doing it the same way as alphapapa in the Ement repository https://github.com/alphapapa/ement.el

Except that I am not bundling the makem.sh script into this repository but downloading it through the GitHub action.